### PR TITLE
Add base.v0.14.2

### DIFF
--- a/packages/base/base.v0.14.2/opam
+++ b/packages/base/base.v0.14.2/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/base"
+bug-reports: "https://github.com/janestreet/base/issues"
+dev-repo: "git+https://github.com/janestreet/base.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/base/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"             {>= "4.07.0" }
+  "sexplib0"          {>= "v0.14" & < "v0.15"}
+  "dune"              {>= "2.0.0"}
+  "dune-configurator"
+]
+synopsis: "Full standard library replacement for OCaml"
+description: "
+Full standard library replacement for OCaml
+
+Base is a complete and portable alternative to the OCaml standard
+library. It provides all standard functionalities one would expect
+from a language standard library. It uses consistent conventions
+across all of its module.
+
+Base aims to be usable in any context. As a result system dependent
+features such as I/O are not offered by Base. They are instead
+provided by companion libraries such as stdio:
+
+  https://github.com/janestreet/stdio
+"
+url {
+ src: "https://github.com/TheLortex/base/archive/v0.14.2+fix-dep.zip"
+}


### PR DESCRIPTION
This package is a fake one which should be deleted soon by the release cycle of JaneStreet. It includes a small patch from @TheLorex to ensure the separation of the host and the target toolchain. The next release of `base` will include it for sure (the patch was already merged) but, to unlock the release cycle of MirageOS, we put it into our overlays for a time.