### PR TITLE
The last version of gmp requires ocaml-solo5.0.8.3 at least

### DIFF
--- a/packages/zarith/zarith.1.12+dune+mirage/opam
+++ b/packages/zarith/zarith.1.12+dune+mirage/opam
@@ -16,6 +16,9 @@ depends: [
   "dune"
   ("gmp" | "conf-gmp" )
 ]
+conflicts: [
+  "ocaml-solo5" {< "0.8.3"}
+]
 synopsis:
   "Implements arithmetic and logical operations over arbitrary-precision integers"
 description: """


### PR DESCRIPTION
But we still are able to solve older version of gmp with any ocaml-solo5 versions and we continue to support, at last, conf-gmp.

It should solve mirage/ocaml-gmp#23. /cc @hannesm